### PR TITLE
AzureFileStorage return files array

### DIFF
--- a/src/AzureFileStorage.cs
+++ b/src/AzureFileStorage.cs
@@ -40,6 +40,8 @@ namespace AdminShell
                     {
                         files.Add(blobItem.Name);
                     }
+
+                    return files.ToArray();
                 }
 
                 return null;


### PR DESCRIPTION
FindAllFilesAsync must return the string array of the files found in the blob. As is now, method always returns null